### PR TITLE
Introduce static versioning and initial CHANGELOG

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This project adheres to Semantic Versioning (https://semver.org/).
+
+v1.0.0 - 2026-04-28
+- Introduced static versioning via src/version.h
+- Added CHANGELOG.md for project tracking
+- Removed Git-based version generation from the Makefile

--- a/makefile
+++ b/makefile
@@ -6,6 +6,7 @@
 sysconf : HEADERS	=	\
 	src/parse-config.h	\
 	src/print-config.h	\
+	src/version.h	\
 	src/abort.h
 
 sysconf : SOURCES	=	\
@@ -40,11 +41,6 @@ REMOVE		:=	rm -f
 CP			:=	cp
 CTAGS       :=	ctags
 
-# for BSD
-HASH_VERSION:sh	= git rev-parse --short=7 HEAD
-# for GNU (ignored by non-gmake versions)
-HASH_VERSION 	?= $(shell git rev-parse --short=7 HEAD)
-
 OBJECTS = $(SOURCES:.c=.o)
 #--------------------------------------------------------------------
 # Define the target compile instructions.
@@ -56,9 +52,7 @@ OBJECTS = $(SOURCES:.c=.o)
 
 sysconf: $(HEADERS) ctags cleanobjs
 	SYSCONF_TARGET='sysconf'
-		@echo "const char program_version[] = \"${HASH_VERSION}\";" > src/version.h
 		@$(CC) $(CFLAGS) $(INCPATH) -o sysconf $(SOURCES)
-		@rm src/version.h
 
 .PHONY: test
 test: $(HEADERS) $(TEST_HEADERS)

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,1 @@
+const char program_version[] = "1.0.0";


### PR DESCRIPTION
This PR replaces dynamic Git-based versioning with a static src/version.h.

This change resolves permission issues encountered when running make install under doas/sudo and simplifies the build process by removing runtime Git dependency.

Included changes:

- Added static src/version.h (v1.0.0)
- Removed Git-based version generation from the Makefile
- Removed version injection during build
- Added CHANGELOG.md for project tracking